### PR TITLE
Fix ValueError by doing a max split of two items

### DIFF
--- a/willump/proc_utils.py
+++ b/willump/proc_utils.py
@@ -4,7 +4,7 @@ def parse_cmdline_args(cmdline_args):
     cmdline_args_parsed = {}
     for cmdline_arg in cmdline_args:
         if len(cmdline_arg) > 0 and '=' in cmdline_arg:
-            key, value = cmdline_arg[2:].split('=')
+            key, value = cmdline_arg[2:].split('=', 1)
             cmdline_args_parsed[key] = value
     return cmdline_args_parsed
 


### PR DESCRIPTION
Fixes #7 since a command line argument can contain multiple `=` characters i.e. `--riotgamesapi-settings=A0jla9nadf9==`.