### PR TITLE
Requested close

### DIFF
--- a/willump/willump.py
+++ b/willump/willump.py
@@ -102,7 +102,7 @@ class Willump:
                 elif msg.type == aiohttp.WSMsgType.CLOSED:
                     logging.info('received websocket message CLOSE, ending listening loop')
                     break
-
+            await self.close()             
         self.ws_loop_task = asyncio.create_task(begin_ws_loop(self))
         self.websocket_alive = True
         logging.info("began LCUx websocket loop")

--- a/willump/willump.py
+++ b/willump/willump.py
@@ -79,6 +79,7 @@ class Willump:
         self.subscription_tasks = []
 
         async def begin_ws_loop(self):
+            logging.info('Starting websocket message loop')
             async for msg in self.ws_client:
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     if not msg.data:
@@ -102,7 +103,7 @@ class Willump:
                 elif msg.type == aiohttp.WSMsgType.CLOSED:
                     logging.info('received websocket message CLOSE, ending listening loop')
                     break
-            await self.close()             
+            await self.close() 
         self.ws_loop_task = asyncio.create_task(begin_ws_loop(self))
         self.websocket_alive = True
         logging.info("began LCUx websocket loop")
@@ -172,6 +173,7 @@ class Willump:
                 await self.ws_client.send_json([Event_Code.UNSUBSCRIBE.value, event])
 
     async def close(self):
+        logging.info('Closing willump')
         if self.rest_alive:
             await self.close_rest()
         if self.websocket_alive:
@@ -180,22 +182,27 @@ class Willump:
             await self.close_nunu()
         if self.live_events_alive:
             await self.close_live_events()
+        logging.info('Willump Closed')
+        
 
     async def close_rest(self):
         await self.https_session.close()
         self.rest_alive = False
+        logging.info('Closed rest')
 
     async def close_websocket(self):
         await self.ws_client.close()
         await self.ws_session.close()
-        await self.ws_loop_task.cancel()
+        self.ws_loop_task.cancel()
         await asyncio.gather(*self.subscription_tasks)
         self.websocket_alive = False
+        logging.info('Closed websocket')
 
     async def close_nunu(self):
         await self.nunu.close()
         self.nunu_alive = False
-
+        logging.info('Closed Nunu')
     async def close_live_events(self):
         await self.live_events.close()
         self.live_events_alive = False
+        logging.info('Closed live events')

--- a/willump/willump.py
+++ b/willump/willump.py
@@ -188,7 +188,7 @@ class Willump:
     async def close_websocket(self):
         await self.ws_client.close()
         await self.ws_session.close()
-        await self.ws_loop_task
+        await self.ws_loop_task.cancel()
         await asyncio.gather(*self.subscription_tasks)
         self.websocket_alive = False
 


### PR DESCRIPTION
Added a function called request_close() that sets a new Boolean attribute of willump called close_requested to True. Added a break inside the websocket message loop if close_requested is True. 

I also changed a line in the close() function where a task was awaited. Now the task is cancelled instead, allowing willump to actually close. 

To help with debugging I added some extra logging around the closing functions.
